### PR TITLE
Blob Store Impl + Comments without "E" Implementation

### DIFF
--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -82,7 +82,7 @@
         <version>2.2.0</version>
         <configuration>
           <!-- TODO: set project ID. -->
-          <deploy.projectId>ariagno-step-3</deploy.projectId>
+          <deploy.projectId>kirankubetest2</deploy.projectId>
           <deploy.version>1</deploy.version>
         </configuration>
       </plugin>

--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -41,6 +41,12 @@
         <artifactId>appengine-api-1.0-sdk</artifactId>
         <version>1.9.59</version>
     </dependency>
+
+    <dependency>
+        <groupId>com.google.appengine</groupId>
+        <artifactId>appengine-api-1.0-sdk</artifactId>
+        <version>1.9.59</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -43,12 +43,6 @@
     </dependency>
 
     <dependency>
-        <groupId>com.google.appengine</groupId>
-        <artifactId>appengine-api-1.0-sdk</artifactId>
-        <version>1.9.59</version>
-    </dependency>
-
-    <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-language</artifactId>
         <version>1.55.0</version>

--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -46,6 +46,8 @@
         <groupId>com.google.appengine</groupId>
         <artifactId>appengine-api-1.0-sdk</artifactId>
         <version>1.9.59</version>
+    </dependency>
+
     <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-language</artifactId>

--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -15,8 +15,25 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <failOnMissingWebXml>false</failOnMissingWebXml>
   </properties>
-
+  
+<dependencyManagement>
   <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>libraries-bom</artifactId>
+      <version>5.5.0</version>
+      <type>pom</type>
+      <scope>import</scope>
+    </dependency>
+  </dependencies>
+</dependencyManagement>
+
+<dependencies>
+  <dependency>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>google-cloud-bigquery</artifactId>
+  </dependency>
+
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
@@ -47,6 +64,13 @@
         <artifactId>google-cloud-language</artifactId>
         <version>1.55.0</version>
     </dependency>
+
+    <dependency>
+        <groupId>com.googlecode.json-simple</groupId>
+        <artifactId>json-simple</artifactId>
+        <version>1.1.1</version>
+    </dependency>
+
   </dependencies>
   <build>
     <plugins>
@@ -58,7 +82,7 @@
         <version>2.2.0</version>
         <configuration>
           <!-- TODO: set project ID. -->
-          <deploy.projectId>ariagno-step-2020</deploy.projectId>
+          <deploy.projectId>ariagno-step-3</deploy.projectId>
           <deploy.version>1</deploy.version>
         </configuration>
       </plugin>

--- a/portfolio/src/main/java/com/google/sps/servlets/BlobstoreUploadUrlServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/BlobstoreUploadUrlServlet.java
@@ -1,0 +1,27 @@
+package com.google.sps.servlets;
+
+import com.google.appengine.api.blobstore.BlobstoreService;
+import com.google.appengine.api.blobstore.BlobstoreServiceFactory;
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * When the fetch() function requests the /blobstore-upload-url URL, the content of the response is
+ * the URL that allows a user to upload a file to Blobstore. If this sounds confusing, try running a
+ * dev server and navigating to /blobstore-upload-url to see the Blobstore URL.
+ */
+@WebServlet("/blobstore-upload-url")
+public class BlobstoreUploadUrlServlet extends HttpServlet {
+
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    BlobstoreService blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
+    String uploadUrl = blobstoreService.createUploadUrl("/data");
+
+    response.setContentType("text/html");
+    response.getWriter().println(uploadUrl);
+  }
+}

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -143,16 +143,6 @@ public class DataServlet extends HttpServlet {
         taskEntity.setProperty("score", String.valueOf(score));
         datastore.put(taskEntity);
 
-
-        // BlobstoreService blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
-        // Map<String, List<BlobKey>> blobs = blobstoreService.getUploads(request);
-        // List<BlobKey> blobKeys = blobs.get("image");
-
-
-        // // Our form only contains a single file input, so get the first index.
-        // BlobKey blobKey = blobKeys.get(0);
-
-        // blobstoreService.serve(blobKey, response);
     }
 
 	/**

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -103,7 +103,7 @@ public class DataServlet extends HttpServlet {
 	@Override
   	public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
         response.setContentType("application/json;");
-        
+                Gson gson = new Gson();
         Document doc = Document.newBuilder()
                 .setContent(getPostComment(request))
                 .setType(Document.Type.PLAIN_TEXT)
@@ -112,6 +112,7 @@ public class DataServlet extends HttpServlet {
         Sentiment sentiment = languageService.analyzeSentiment(doc).getDocumentSentiment();
         float score = sentiment.getScore();
         languageService.close();
+        response.getWriter().println(gson.toJson( request.getParameter("image")));        
 
         Entity taskEntity = new Entity("comments");
         taskEntity.setProperty("name", getPostName(request));
@@ -119,6 +120,7 @@ public class DataServlet extends HttpServlet {
         taskEntity.setProperty("image", getUploadedFileUrl(request, "image"));
         taskEntity.setProperty("score", String.valueOf(score));
         datastore.put(taskEntity);
+
     }
 
 	/**
@@ -152,7 +154,7 @@ public class DataServlet extends HttpServlet {
   private String getUploadedFileUrl(HttpServletRequest request, String formInputElementName) {
     BlobstoreService blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
     Map<String, List<BlobKey>> blobs = blobstoreService.getUploads(request);
-    List<BlobKey> blobKeys = blobs.get("image");
+    List<BlobKey> blobKeys = blobs.get(formInputElementName);
 
     // User submitted form without selecting a file, so we can't get a URL. (dev server)
     if (blobKeys == null || blobKeys.isEmpty()) {

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -22,6 +22,20 @@ import javax.servlet.http.*;
 import java.util.Arrays; 
 import com.google.gson.Gson;
 import java.util.*;
+import com.google.appengine.api.blobstore.BlobInfo;
+import com.google.appengine.api.blobstore.BlobInfoFactory;
+import com.google.appengine.api.blobstore.BlobKey;
+import com.google.appengine.api.blobstore.BlobstoreService;
+import com.google.appengine.api.blobstore.BlobstoreServiceFactory;
+import com.google.appengine.api.images.ImagesService;
+import com.google.appengine.api.images.ImagesServiceFactory;
+import com.google.appengine.api.images.ServingUrlOptions;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
 import com.google.common.util.concurrent.*;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
@@ -67,6 +81,7 @@ public class DataServlet extends HttpServlet {
             newEntity.put("name", htmlInjectionPreventer((String) entity.getProperty("name")));
             newEntity.put("comment", htmlInjectionPreventer((String) entity.getProperty("comment")));
             newEntity.put("id", String.valueOf(entity.getKey().getId()));
+            newEntity.put("image", (String) entity.getProperty("image"));
             output.add(newEntity);
         }
 
@@ -89,7 +104,7 @@ public class DataServlet extends HttpServlet {
         Entity taskEntity = new Entity("comments");
         taskEntity.setProperty("name", getPostName(request));
         taskEntity.setProperty("comment", getPostComment(request));
-
+        taskEntity.setProperty("image", getUploadedFileUrl(request, "image"));
         datastore.put(taskEntity);
     }
 
@@ -120,4 +135,41 @@ public class DataServlet extends HttpServlet {
         return str.replace("<", "&lt;").replace(">", "&gt;");
     }
 
+  /** Returns a URL that points to the uploaded file, or null if the user didn't upload a file. */
+  private String getUploadedFileUrl(HttpServletRequest request, String formInputElementName) {
+    BlobstoreService blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
+    Map<String, List<BlobKey>> blobs = blobstoreService.getUploads(request);
+    List<BlobKey> blobKeys = blobs.get("image");
+
+    // User submitted form without selecting a file, so we can't get a URL. (dev server)
+    if (blobKeys == null || blobKeys.isEmpty()) {
+      return null;
+    }
+
+    // Our form only contains a single file input, so get the first index.
+    BlobKey blobKey = blobKeys.get(0);
+
+    // User submitted form without selecting a file, so we can't get a URL. (live server)
+    BlobInfo blobInfo = new BlobInfoFactory().loadBlobInfo(blobKey);
+    if (blobInfo.getSize() == 0) {
+      blobstoreService.delete(blobKey);
+      return null;
+    }
+
+    // We could check the validity of the file here, e.g. to make sure it's an image file
+    // https://stackoverflow.com/q/10779564/873165
+
+    // Use ImagesService to get a URL that points to the uploaded file.
+    ImagesService imagesService = ImagesServiceFactory.getImagesService();
+    ServingUrlOptions options = ServingUrlOptions.Builder.withBlobKey(blobKey);
+
+    // To support running in Google Cloud Shell with AppEngine's devserver, we must use the relative
+    // path to the image, rather than the path returned by imagesService which contains a host.
+    try {
+      URL url = new URL(imagesService.getServingUrl(options));
+      return url.getPath();
+    } catch (MalformedURLException e) {
+      return imagesService.getServingUrl(options);
+    }
+  }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -91,7 +91,7 @@ public class DataServlet extends HttpServlet {
         Query query = new Query("comments");
         PreparedQuery results = datastore.prepare(query);
         String websafeCursor = request.getParameter("cursor");
-        if(null != websafeCursor) {
+        if("" != websafeCursor) {
             fetchOptions.startCursor(Cursor.fromWebSafeString(websafeCursor));
         }
 
@@ -108,7 +108,7 @@ public class DataServlet extends HttpServlet {
         JSONObject json = new JSONObject();
         
         json.put("comments", output);
-        json.put("cursor", results.asQueryResultList(FetchOptions.Builder.withLimit(Integer.parseInt(request.getParameter("amount")))).getCursor().toWebSafeString());
+        json.put("cursor", results.asQueryResultList(fetchOptions).getCursor().toWebSafeString());
         
         response.getWriter().println(gson.toJson(json));
     }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -121,6 +121,16 @@ public class DataServlet extends HttpServlet {
         taskEntity.setProperty("score", String.valueOf(score));
         datastore.put(taskEntity);
 
+
+        // BlobstoreService blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
+        // Map<String, List<BlobKey>> blobs = blobstoreService.getUploads(request);
+        // List<BlobKey> blobKeys = blobs.get("image");
+
+
+        // // Our form only contains a single file input, so get the first index.
+        // BlobKey blobKey = blobKeys.get(0);
+
+        // blobstoreService.serve(blobKey, response);
     }
 
 	/**
@@ -165,14 +175,14 @@ public class DataServlet extends HttpServlet {
     BlobKey blobKey = blobKeys.get(0);
 
     // User submitted form without selecting a file, so we can't get a URL. (live server)
-    BlobInfo blobInfo = new BlobInfoFactory().loadBlobInfo(blobKey);
+    BlobInfo blobInfo = new BlobInfoFactory(datastore).loadBlobInfo(blobKey);
     if (blobInfo.getSize() == 0) {
       blobstoreService.delete(blobKey);
       return null;
     }
 
     ImagesService imagesService = ImagesServiceFactory.getImagesService();
-    ServingUrlOptions options = ServingUrlOptions.Builder.withBlobKey(blobKey);
+    ServingUrlOptions options = ServingUrlOptions.Builder.withGoogleStorageFileName(blobInfo.getGsObjectName());
     return imagesService.getServingUrl(options);
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -169,20 +169,8 @@ public class DataServlet extends HttpServlet {
       return null;
     }
 
-    // We could check the validity of the file here, e.g. to make sure it's an image file
-    // https://stackoverflow.com/q/10779564/873165
-
-    // Use ImagesService to get a URL that points to the uploaded file.
     ImagesService imagesService = ImagesServiceFactory.getImagesService();
     ServingUrlOptions options = ServingUrlOptions.Builder.withBlobKey(blobKey);
-
-    // To support running in Google Cloud Shell with AppEngine's devserver, we must use the relative
-    // path to the image, rather than the path returned by imagesService which contains a host.
-    try {
-      URL url = new URL(imagesService.getServingUrl(options));
-      return url.getPath();
-    } catch (MalformedURLException e) {
-      return imagesService.getServingUrl(options);
-    }
+    return imagesService.getServingUrl(options);
   }
 }

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -246,20 +246,32 @@
                 </form>
             </div>
             <div class = "comment-section" id = "comment-section">
-                <div class = "controls">
-                    <h5>Comments: </h5>
-                    <button onclick = "deleteAllComments()" type="submit" class="btn btn-primary"><i class="fas fa-trash-alt"></i> Delete All Comments</button>
-                    <div class = "form-controls">
-                        <small>Comment Amount: </small>
-                        <div class="input-group">
-                        <select id="comment-amount" class="form-control">
-                            <option>5</option>
-                            <option>10</option>
-                            <option>15</option>
-                        </select>            
-                        <span class="input-group-btn">
-                            <button onclick = "fetchComments()" class="btn btn-default" type="button" tabindex="-1" data-toggle="tooltip" data-placement="top" title="Refresh Comments!"><i class="fas fa-retweet"></i></button>
-                        </span>
+                <div class="container">
+                    <div class="row">
+                        <div class="col">
+                            <div class = "controls">
+                                <h5>Comments: </h5>
+                                <button onclick = "deleteAllComments()" type="submit" class="btn btn-primary"><i class="fas fa-trash-alt"></i> Delete All Comments</button>
+                                <div class = "form-controls">
+                                    <small>Comment Amount: </small>
+                                    <div class="input-group">
+                                    <select id="comment-amount" class="form-control">
+                                        <option>5</option>
+                                        <option>10</option>
+                                        <option>15</option>
+                                    </select>            
+                                    <span class="input-group-btn">
+                                        <button onclick = "fetchComments()" class="btn btn-default" type="button" tabindex="-1" data-toggle="tooltip" data-placement="top" title="Refresh Comments!"><i class="fas fa-retweet"></i></button>
+                                    </span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col">
+                            <div class = "statistics">
+                                <h6>Comment Statistics: </h6>
+                                <small>Comments without the letter E: </small> <small id = "e-stat"></small>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -241,7 +241,8 @@
                         <input type="file" class="custom-file-input" id="image-file">
                         <label class="custom-file-label" for="customFile">Upload a Photo...</label>
                     </div>
-                    <button type="submit" class="btn btn-primary">Submit</button>
+                    
+                    <button id = "btn-submit" type="submit" class="btn btn-primary">Submit</button>
                 </form>
             </div>
             <div class = "comment-section" id = "comment-section">
@@ -252,9 +253,9 @@
                         <small>Comment Amount: </small>
                         <div class="input-group">
                         <select id="comment-amount" class="form-control">
-                            <option>25</option>
-                            <option>50</option>
-                            <option>100</option>
+                            <option>5</option>
+                            <option>10</option>
+                            <option>15</option>
                         </select>            
                         <span class="input-group-btn">
                             <button onclick = "fetchComments()" class="btn btn-default" type="button" tabindex="-1" data-toggle="tooltip" data-placement="top" title="Refresh Comments!"><i class="fas fa-retweet"></i></button>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -234,8 +234,13 @@
                         <label for="exampleInputEmail1">Name</label>
                         <input name="name" class="form-control" id="name" aria-describedby="nameHelp"  autocomplete="off">
                     </div>
-                        <label for="message" autocomplete="off">Message</label>
-                        <textarea name="comment" class="form-control" id="exampleFormControlTextarea1" rows="3"></textarea>
+                    <label for="message" autocomplete="off">Message</label>
+                    <textarea name="comment" class="form-control" id="exampleFormControlTextarea1" rows="3"></textarea>
+
+                    <div class="custom-file file-browser">
+                        <input type="file" class="custom-file-input" id="image-file">
+                        <label class="custom-file-label" for="customFile">Upload a Photo...</label>
+                    </div>
                     <button type="submit" class="btn btn-primary">Submit</button>
                 </form>
             </div>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -247,8 +247,8 @@
             </div>
             <div class = "comment-section" id = "comment-section">
                 <div class="container">
-                    <div class="row">
-                        <div class="col">
+                    <!-- <div class="row"> -->
+                        <!-- <div class="col"> -->
                             <div class = "controls">
                                 <h5>Comments: </h5>
                                 <button onclick = "deleteAllComments()" type="submit" class="btn btn-primary"><i class="fas fa-trash-alt"></i> Delete All Comments</button>
@@ -266,14 +266,14 @@
                                     </div>
                                 </div>
                             </div>
-                        </div>
-                        <div class="col">
+                        <!-- </div> -->
+                        <!-- <div class="col">
                             <div class = "statistics">
                                 <h6>Comment Statistics: </h6>
                                 <small>Comments without the letter E: </small> <small id = "e-stat"></small>
                             </div>
-                        </div>
-                    </div>
+                        </div> -->
+                    <!-- </div> -->
                 </div>
 
                 <div id = "raw-comments">

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -279,6 +279,7 @@
                 <div id = "raw-comments">
                 
                 </div>
+                <div id = "load-more" class = "load-more" onClick="loadMoreComments()">Load More Comments <i class="fas fa-angle-double-right"></i> </div>
             </div> 
         </div>
         <script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>

--- a/portfolio/src/main/webapp/js/script.js
+++ b/portfolio/src/main/webapp/js/script.js
@@ -1,8 +1,8 @@
 let scene = new THREE.Scene();
 let camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 0.1, 1000 );
-let endpoint = 'https://ariagno-step-2020.uc.r.appspot.com/data'
-let deleteSingleCommentEndpoint = 'https://ariagno-step-2020.uc.r.appspot.com/deleteSingleComment'
-let deleteAllCommentsEndpoint = 'https://ariagno-step-2020.uc.r.appspot.com/deleteAllComments'
+let endpoint = '/data'
+let deleteSingleCommentEndpoint = '/deleteSingleComment'
+let deleteAllCommentsEndpoint = '/deleteAllComments'
 
 let renderer = new THREE.WebGLRenderer();
 let container = document.getElementById('world');
@@ -78,8 +78,13 @@ function submitCommentForm() {
         console.log(photo);
         let formData = new FormData();
         formData.append("image", photo);                                
-        formData.append("name", name)
-        formData.append("comment", comments);
+        formData.append("name", document.forms["comments"]["name"].value)
+        formData.append("comment", document.forms["comments"]["comment"].value);
+
+        for (var pair of formData.entries()) {
+            console.log(pair[0]+ ', ' + pair[1]); 
+        }
+
         var xhr = new XMLHttpRequest();
         fetch('/blobstore-upload-url').then((response) => {
             return response.text();
@@ -120,7 +125,7 @@ fetchComments = function () {
     document.getElementById("raw-comments").innerHTML = '';
     fetch(endpoint + formatParams(amount)).then(e => e.json()).then((resp) => {
         comments = resp;
-
+        console.log(resp)
         for(comment of resp) {
             commentSection = document.getElementById("raw-comments");
             // Creates the new comment div class to append

--- a/portfolio/src/main/webapp/js/script.js
+++ b/portfolio/src/main/webapp/js/script.js
@@ -107,6 +107,33 @@ function submitCommentForm() {
     }
 }
 
+loadMoreComments = function() {
+    var amount = {
+        amount: document.getElementById( "comment-amount" ).value,
+        cursor: cursor
+    }	
+    fetch(endpoint + formatParams(amount)).then(e => e.json()).then((resp) => {
+        comments += resp["comments"];
+        cursor = resp["cursor"];
+        for(comment of resp["comments"]) {
+            commentSection = document.getElementById("raw-comments");
+            // Creates the new comment div class to append
+            let newComment = document.createElement("div")
+            newComment.classList.add("comment")
+
+            // The actual html, uses the string formatting tool to append it
+            newComment.innerHTML = (`
+            	<button class="btn btn-primary delete" onclick='deleteComment("${comment["id"]}")'>
+                    <i class="fas fa-trash-alt"></i>
+                </button> 
+                <b>${comment['name']}</b> wrote ${comment['comment']}
+                <br><small>This commenter is feeling: ${returnFeelingEmoji(comment["score"])}</small>
+            `)
+            commentSection.appendChild(newComment)
+        }
+    })
+}
+
 enableButton = function() {
     $("#btn-submit").prop("disabled", false);
     $("#btn-submit").html(`Submit`);
@@ -132,12 +159,16 @@ window.onload = () => {
 fetchComments = function () {
     var amount = {
         amount: document.getElementById( "comment-amount" ).value,
-        cursor: cursor
+        cursor: ""
     }	
-    document.getElementById("raw-comments").innerHTML = '';
+    document.getElementById("raw-comments").innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>';
+
     fetch(endpoint + formatParams(amount)).then(e => e.json()).then((resp) => {
         comments = resp["comments"];
         cursor = resp["cursor"];
+        if(resp["comments"].length == 0) {
+            document.getElementById("load-more").style.display = "none";
+        }
         for(comment of comments) {
             commentSection = document.getElementById("raw-comments");
             // Creates the new comment div class to append

--- a/portfolio/src/main/webapp/js/script.js
+++ b/portfolio/src/main/webapp/js/script.js
@@ -74,22 +74,18 @@ function validateForm() {
  */
 function submitCommentForm() {
     if(validateForm()) {
+
         let photo = document.getElementById("image-file").files[0];  // file from input
-        console.log(photo);
         let formData = new FormData();
         formData.append("image", photo);                                
         formData.append("name", document.forms["comments"]["name"].value)
         formData.append("comment", document.forms["comments"]["comment"].value);
 
-        for (var pair of formData.entries()) {
-            console.log(pair[0]+ ', ' + pair[1]); 
-        }
-
+        disableButton();
         var xhr = new XMLHttpRequest();
         fetch('/blobstore-upload-url').then((response) => {
             return response.text();
         }).then((imageUploadUrl) => {
-            console.log(imageUploadUrl)
             xhr.open('POST', imageUploadUrl, true);
             xhr.send(formData);
             xhr.onload = function() {
@@ -97,14 +93,26 @@ function submitCommentForm() {
                 if(xhr.status == 200) {
                     $('#response').text("Successfully posted your comment!")
                     $('#myModal').modal()
+                    enableButton();
                     fetchComments();
                 } else {
                     $('#response').text("Unable to submit your comment, try again later!")
                     $('#myModal').modal()
+                    enableButton();
                 }
             }
         });
     }
+}
+
+enableButton = function() {
+    $("#btn-submit").prop("disabled", false);
+    $("#btn-submit").html(`Submit`);
+}
+
+disableButton = function() {
+    $("#btn-submit").prop("disabled", true);
+    $("#btn-submit").html(`<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Submitting Comment...`);
 }
 
 // Used to prevent default redirect behavior
@@ -125,7 +133,6 @@ fetchComments = function () {
     document.getElementById("raw-comments").innerHTML = '';
     fetch(endpoint + formatParams(amount)).then(e => e.json()).then((resp) => {
         comments = resp;
-        console.log(resp)
         for(comment of resp) {
             commentSection = document.getElementById("raw-comments");
             // Creates the new comment div class to append

--- a/portfolio/src/main/webapp/js/script.js
+++ b/portfolio/src/main/webapp/js/script.js
@@ -115,6 +115,9 @@ loadMoreComments = function() {
     fetch(endpoint + formatParams(amount)).then(e => e.json()).then((resp) => {
         comments += resp["comments"];
         cursor = resp["cursor"];
+        if(resp["comments"].length == 0) {
+            document.getElementById("load-more").style.display = "none";
+        }
         for(comment of resp["comments"]) {
             commentSection = document.getElementById("raw-comments");
             // Creates the new comment div class to append
@@ -141,7 +144,7 @@ enableButton = function() {
 
 disableButton = function() {
     $("#btn-submit").prop("disabled", true);
-    $("#btn-submit").html(`<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Submitting Comment...`);
+    $("#btn-submit").html(`<span id = "loader" class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Submitting Comment...`);
 }
 
 // Used to prevent default redirect behavior
@@ -151,7 +154,7 @@ $('#comments').submit(function (evt) {
 
 window.onload = () => {
 	fetchComments();
-    getEStatstic();
+    // getEStatstic();
 }
 
 // fetch comments is used to GET comments from our API
@@ -161,7 +164,7 @@ fetchComments = function () {
         amount: document.getElementById( "comment-amount" ).value,
         cursor: ""
     }	
-    document.getElementById("raw-comments").innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>';
+    document.getElementById("raw-comments").innerHTML = '<span id = "loader" class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>';
 
     fetch(endpoint + formatParams(amount)).then(e => e.json()).then((resp) => {
         comments = resp["comments"];
@@ -183,8 +186,14 @@ fetchComments = function () {
                 <b>${comment['name']}</b> wrote ${comment['comment']}
                 <br><small>This commenter is feeling: ${returnFeelingEmoji(comment["score"])}</small>
             `)
+            if(comment["image"] != null) {
+                let commentImage = document.createElement("img");
+                commentImage.src = comment["image"];
+                newComment.appendChild(commentImage);
+            }
             commentSection.appendChild(newComment)
         }
+        document.getElementById("loader").remove();
     })
 }
 

--- a/portfolio/src/main/webapp/js/script.js
+++ b/portfolio/src/main/webapp/js/script.js
@@ -84,21 +84,30 @@ function submitCommentForm() {
             comment: comments   
         };
 
+        let photo = document.getElementById("image-file").files[0];  // file from input
+        let formData = new FormData();
+        formData.append("photo", photo);                                
+        formData.append("name", name)
+        formData.append("comment", comments);
         var xhr = new XMLHttpRequest();
-        xhr.open('POST', endpoint + formatParams(data), true);
-        // Need to use this request header in order for servelet to read in values
-        xhr.setRequestHeader('Content-type', 'application/x-www-form-urlencoded')
-        xhr.send(null);
-        xhr.onload = function() {
-            // Good response
-            if(xhr.status == 200) {
-                $('#myModal').modal()
-    	        fetchComments();
-            } else {
-                $('#response').text("Unable to submit your comment, try again later!")
-                $('#myModal').modal()
+
+        fetch('/blobstore-upload-url').then((response) => {
+            return response.text();
+        }).then((imageUploadUrl) => {
+            console.log(imageUploadUrl)
+            xhr.open('POST', imageUploadUrl, true);
+            xhr.send(formData);
+            xhr.onload = function() {
+                // Good response
+                if(xhr.status == 200) {
+                    $('#myModal').modal()
+                    fetchComments();
+                } else {
+                    $('#response').text("Unable to submit your comment, try again later!")
+                    $('#myModal').modal()
+                }
             }
-        }
+        });
     }
 }
 
@@ -135,6 +144,7 @@ fetchComments = function () {
         }
     })
 }
+
 
 deleteComment = function(id) {
     var idHash = {

--- a/portfolio/src/main/webapp/js/script.js
+++ b/portfolio/src/main/webapp/js/script.js
@@ -74,19 +74,10 @@ function validateForm() {
  */
 function submitCommentForm() {
     if(validateForm()) {
-        // Grabs name + message from user in form
-        let name = document.forms["comments"]["name"].value;
-        let comments = document.forms["comments"]["comment"].value;
-
-        // Assembles into a nice data structure, easier to read
-        let data = {
-            name: name,
-            comment: comments   
-        };
-
         let photo = document.getElementById("image-file").files[0];  // file from input
+        console.log(photo);
         let formData = new FormData();
-        formData.append("photo", photo);                                
+        formData.append("image", photo);                                
         formData.append("name", name)
         formData.append("comment", comments);
         var xhr = new XMLHttpRequest();

--- a/portfolio/src/main/webapp/js/script.js
+++ b/portfolio/src/main/webapp/js/script.js
@@ -9,6 +9,7 @@ let container = document.getElementById('world');
 let w = container.offsetWidth;
 let h = container.offsetHeight;
 let comments = [];
+let cursor = "";
 
 renderer.setSize(w, h);
 container.appendChild(renderer.domElement);
@@ -80,6 +81,7 @@ function submitCommentForm() {
         formData.append("image", photo);                                
         formData.append("name", document.forms["comments"]["name"].value)
         formData.append("comment", document.forms["comments"]["comment"].value);
+        formData.append("cursor", cursor);
 
         disableButton();
         var xhr = new XMLHttpRequest();
@@ -122,18 +124,21 @@ $('#comments').submit(function (evt) {
 
 window.onload = () => {
 	fetchComments();
+    getEStatstic();
 }
 
 // fetch comments is used to GET comments from our API
 // appends the results over to the html
 fetchComments = function () {
     var amount = {
-        amount: document.getElementById( "comment-amount" ).value 
+        amount: document.getElementById( "comment-amount" ).value,
+        cursor: cursor
     }	
     document.getElementById("raw-comments").innerHTML = '';
     fetch(endpoint + formatParams(amount)).then(e => e.json()).then((resp) => {
-        comments = resp;
-        for(comment of resp) {
+        comments = resp["comments"];
+        cursor = resp["cursor"];
+        for(comment of comments) {
             commentSection = document.getElementById("raw-comments");
             // Creates the new comment div class to append
             let newComment = document.createElement("div")
@@ -160,6 +165,12 @@ returnFeelingEmoji = function(score) {
     } else {
         return `😐 ${score}`
     }
+}
+
+getEStatstic = function() {
+    fetch('/getNumberofE').then(e => e.json()).then((response) => {
+        document.getElementById("e-stat").textContent = (response["commentsWithoutE"]);
+    })
 }
 
 deleteComment = function(id) {

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -237,6 +237,12 @@ p.small {
     margin: auto;
 }
 
+.statistics {
+    margin: auto;
+    margin-top: .3em;
+    text-align: center;
+}
+
 .delete {
     vertical-align: initial !important;
 }

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -228,6 +228,9 @@ p.small {
     height:15px;
 }
 
+.file-browser {
+    margin:1em;
+}
 .hero {
     text-align: center;
     display:block;

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -153,8 +153,10 @@ h3 {
     width:80%;
 }
 
-.form-controls {
-    width:50%;
+.load-more {
+     cursor:pointer;
+     color:blue;
+     text-align:center;
 }
 
 .portfolio-card article p {

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -10,6 +10,11 @@ a {
     color:black !important;
 }
 
+img {
+    width: 100%;
+    height: 100%;
+}
+
 table {
     margin: 0px auto;
     margin-bottom:3em;
@@ -231,7 +236,7 @@ p.small {
 }
 
 .file-browser {
-    margin:1em;
+    margin-top: 1em;
 }
 .hero {
     text-align: center;
@@ -247,6 +252,10 @@ p.small {
 
 .delete {
     vertical-align: initial !important;
+}
+
+#loader {
+    margin-left: 50%;
 }
 
 @media (min-width: 768px) {

--- a/walkthroughs/week-4-libraries/blobstore/examples/hello-world-fetch/pom.xml
+++ b/walkthroughs/week-4-libraries/blobstore/examples/hello-world-fetch/pom.xml
@@ -38,7 +38,7 @@
         <artifactId>appengine-maven-plugin</artifactId>
         <version>2.2.0</version>
         <configuration>
-          <deploy.projectId>YOUR_PROJECT_ID_HERE</deploy.projectId>
+          <deploy.projectId>ariagno-step-2020</deploy.projectId>
           <deploy.version>1</deploy.version>
         </configuration>
       </plugin>


### PR DESCRIPTION
## Majors
 - Implements a way for users to upload images to Blobstore
    -  Code is implemented, cannot upload though due to permission issues still.
 - Adds a ticker to count the number of comments without the letter E
    - Uses BigQuery with an export of the Datastore database

## Question
 - Is there a way to automate this export? Ie if someone puts a comment in we can update the ticker. My idea was to add the row to datastore then BigQuery, but there doesn't seem to be an actual way to stream data from an API GET or directly from datastore without a full table import

## Screenshot

![image](https://user-images.githubusercontent.com/8387242/84420571-d81c2000-abdf-11ea-8f97-0447c4a6b07a.png)

![image](https://user-images.githubusercontent.com/8387242/85050892-6b170600-b15c-11ea-9bc5-52930f79d12f.png)

